### PR TITLE
[Draft] Feature / Transaction group generation

### DIFF
--- a/src/application_client/application_client.ts
+++ b/src/application_client/application_client.ts
@@ -319,11 +319,11 @@ export class ApplicationClient {
     }
   }
 
-  async getTransactions(
+  async getTxns(
     method: algosdk.ABIMethod,
     args?: MethodArgs,
     txParams?: TransactionOverrides
-  ): Promise<algosdk.Transaction[]> { // TODO: Add correct type
+  ): Promise<algosdk.Transaction[]> {
     const atc = await this.generateAtomicComposer(method, args, txParams);
     return atc['transactions'].map((txnData: { txn: algosdk.Transaction }) => txnData.txn);
   }

--- a/src/application_client/application_client.ts
+++ b/src/application_client/application_client.ts
@@ -319,14 +319,21 @@ export class ApplicationClient {
     }
   }
 
+  async getTransactions(
+    method: algosdk.ABIMethod,
+    args?: MethodArgs,
+    txParams?: TransactionOverrides
+  ): Promise<unknown> { // TODO: Add correct type
+    const atc = await this.generateAtomicComposer(method, args, txParams);
+    return atc['transactions'];
+  }
+
   async call(
     method: algosdk.ABIMethod,
     args?: MethodArgs,
     txParams?: TransactionOverrides
   ): Promise<algosdk.ABIResult> {
-    const atc = new algosdk.AtomicTransactionComposer();
-
-    await this.addMethodCall(atc, method, args, txParams);
+    const atc = await this.generateAtomicComposer(method, args, txParams);
 
     try {
       const result = await atc.execute(this.client, 4);
@@ -337,6 +344,18 @@ export class ApplicationClient {
       throw this.wrapLogicError(e as Error);
     }
   }
+
+  private async generateAtomicComposer(
+		method: algosdk.ABIMethod,
+		args?: MethodArgs,
+		txParams?: TransactionOverrides
+	): Promise<algosdk.AtomicTransactionComposer> {
+		const atc = new algosdk.AtomicTransactionComposer();
+
+		await this.addMethodCall(atc, method, args, txParams);
+
+    return atc;
+	}
 
   async addMethodCall(
     atc: algosdk.AtomicTransactionComposer,

--- a/src/application_client/application_client.ts
+++ b/src/application_client/application_client.ts
@@ -325,6 +325,7 @@ export class ApplicationClient {
     txParams?: TransactionOverrides
   ): Promise<algosdk.Transaction[]> {
     const atc = await this.generateAtomicComposer(method, args, txParams);
+    // TODO: The `transactions` key should at least have an accessor
     return atc['transactions'].map((txnData: { txn: algosdk.Transaction }) => txnData.txn);
   }
 

--- a/src/application_client/application_client.ts
+++ b/src/application_client/application_client.ts
@@ -323,9 +323,9 @@ export class ApplicationClient {
     method: algosdk.ABIMethod,
     args?: MethodArgs,
     txParams?: TransactionOverrides
-  ): Promise<unknown> { // TODO: Add correct type
+  ): Promise<algosdk.Transaction[]> { // TODO: Add correct type
     const atc = await this.generateAtomicComposer(method, args, txParams);
-    return atc['transactions'];
+    return atc['transactions'].map((txnData: { txn: algosdk.Transaction }) => txnData.txn);
   }
 
   async call(

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -222,10 +222,9 @@ function generateClass(appSpec: AppSpec): ts.ClassDeclaration {
       ...appSpec.contract.methods.map((meth) =>
         generateMethodImpl(meth, appSpec)
       ),
-      generateTxnMethodImpl(appSpec.contract.methods[0] as algosdk.ABIMethod, appSpec)
-      // ...appSpec.contract.methods.map((meth) =>
-      //   generateTxnMethodImpl(meth, appSpec)
-      // ),
+      ...appSpec.contract.methods.map((meth) =>
+        generateTxnMethodImpl(meth, appSpec)
+      ),
     ]
   );
 }
@@ -551,7 +550,7 @@ function generateTxnMethodImpl(
         : undefined;
 
     argParams.push(
-      factory.createPropertySignature(undefined, `transactions_${arg.name}`, optional, argType)
+      factory.createPropertySignature(undefined, arg.name, optional, argType)
     );
   }
 


### PR DESCRIPTION
Adds the ability for the client to return the transaction group generated by an app call.

This leverages the use of the ATC, exposing a friendly interface to the client user:

```javascript
await client.transactions.app_external_method(...args)
```

I still need to give this further testing, but it's generating syntactically correct TS.

----

This is useful for the case where transaction composition and signing is decoupled (which is our use case at Agrotoken, in particular!).

@barnjamin I'd appreciate any feedback on this, since it would help us bring beaker-ts into our codebase!